### PR TITLE
Fix abstract class descendants not inheriting custom connection

### DIFF
--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -98,8 +98,9 @@ module Octopus
         around_save :run_on_shard, :unless => -> { self.class.custom_octopus_connection }
         after_initialize :set_current_shard
 
+        cattr_accessor :custom_octopus_connection
+
         class << self
-          attr_accessor :custom_octopus_connection
           attr_accessor :custom_octopus_table_name
 
           alias_method_chain :connection, :octopus

--- a/spec/octopus/model_spec.rb
+++ b/spec/octopus/model_spec.rb
@@ -263,6 +263,12 @@ describe Octopus::Model do
       expect(CustomConnection.connection.current_database).to eq('octopus_shard_2')
     end
 
+    it 'reuses parent model connection' do
+      klass = Class.new(CustomConnection)
+
+      expect(klass.connection).to be klass.connection
+    end
+
     it 'should not mess with custom connection table names' do
       expect(Advert.connection.current_database).to eq('octopus_shard_1')
       Advert.create!(:name => 'Teste')


### PR DESCRIPTION
Fix #219

I'm adding this in to our REPO to fix what was laid out in the original branch.